### PR TITLE
Adding Fields to GraphQL entity call in order to use as backing for all registration types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.brainera</groupId>
   <artifactId>newrelic-api</artifactId>
-  <version>1.0.23</version>
+  <version>1.0.24</version>
   <packaging>jar</packaging>
   <name>New Relic API</name>
   <description>

--- a/src/main/java/com/opsmatters/newrelic/api/model/graphql/EntityLookupResponse.java
+++ b/src/main/java/com/opsmatters/newrelic/api/model/graphql/EntityLookupResponse.java
@@ -1,7 +1,6 @@
 package com.opsmatters.newrelic.api.model.graphql;
 
 import java.util.List;
-import java.util.Locale;
 
 /**
  * Represents Graph QL response data.

--- a/src/main/java/com/opsmatters/newrelic/api/model/graphql/EntityLookupResponse.java
+++ b/src/main/java/com/opsmatters/newrelic/api/model/graphql/EntityLookupResponse.java
@@ -1,6 +1,7 @@
 package com.opsmatters.newrelic.api.model.graphql;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Represents Graph QL response data.
@@ -154,6 +155,9 @@ public class EntityLookupResponse {
     public class EmbeddedEntity {
         private String name;
         private String guid;
+        private List<EmbeddedEntityTag> tags;
+        private Long accountId;
+        private Long applicationId;
 
         public String getGuid() {
             return guid;
@@ -170,6 +174,31 @@ public class EntityLookupResponse {
         public void setName(String name) {
             this.name = name;
         }
+
+        public List<EmbeddedEntityTag> getTags() { return tags; }
+
+        public void setTags(List<EmbeddedEntityTag> tags) { this.tags = tags; }
+
+        public Long getAccountId() { return accountId; }
+
+        public void setAccountId(Long accountId) { this.accountId = accountId; }
+
+        public Long getApplicationId() { return applicationId; }
+
+        public void setApplicationId(Long applicationId) { this.applicationId = applicationId; }
+    }
+
+    public class EmbeddedEntityTag {
+        private String key;
+        private List<String> values;
+
+        public String getKey() { return key; }
+
+        public void setKey(String key) { this.key = key; }
+
+        public List<String> getValues() { return values; }
+
+        public void setValues(List<String> values) { this.values = values; }
     }
 
     public class EntitySearch {


### PR DESCRIPTION
## Change description

Adding the following fields to theentity GraphQL fetch so it can serve as the backing upstream entity for everything we do on Cortex:
- tags
- account ID
- Application ID

## Type of change

Only adds fields to the entity fetch

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
