### PR TITLE
CET-10054 Newrelic - third party metrics support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.brainera</groupId>
   <artifactId>newrelic-api</artifactId>
-  <version>1.0.25</version>
+  <version>1.0.26</version>
   <packaging>jar</packaging>
   <name>New Relic API</name>
   <description>
@@ -103,7 +103,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <tasks>
+              <target>
                 <mkdir dir="${project.build.directory}" />
                 <tstamp>
                   <format property="TODAY" pattern="dd-MM-yyyy HH:mm" timezone="Europe/London" /> 
@@ -112,7 +112,7 @@
                 <echo file="${basedir}/target/filter.properties">build.number=${build.number}
 built.on=${TODAY}
                 </echo>
-              </tasks>
+              </target>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/com/opsmatters/newrelic/api/httpclient/GsonMessageBodyHandler.java
+++ b/src/main/java/com/opsmatters/newrelic/api/httpclient/GsonMessageBodyHandler.java
@@ -65,6 +65,7 @@ import com.opsmatters.newrelic.api.httpclient.deserializers.graphql.NrqlErrorRes
 import com.opsmatters.newrelic.api.httpclient.deserializers.graphql.NrqlQueryResponseDeserializer;
 import com.opsmatters.newrelic.api.httpclient.deserializers.graphql.NrqlSuccessResponseDeserializer;
 import com.opsmatters.newrelic.api.httpclient.deserializers.graphql.SloDefinitionResponseDeserializer;
+import com.opsmatters.newrelic.api.httpclient.deserializers.graphql.ThirdPartyMetricsResponseDeserializer;
 import com.opsmatters.newrelic.api.httpclient.deserializers.insights.DashboardDeserializer;
 import com.opsmatters.newrelic.api.httpclient.deserializers.insights.DashboardsDeserializer;
 import com.opsmatters.newrelic.api.httpclient.deserializers.labels.LabelDeserializer;
@@ -131,6 +132,7 @@ import com.opsmatters.newrelic.api.model.graphql.NrqlErrorResponse;
 import com.opsmatters.newrelic.api.model.graphql.NrqlQueryResponse;
 import com.opsmatters.newrelic.api.model.graphql.NrqlSuccessResponse;
 import com.opsmatters.newrelic.api.model.graphql.SloDefinitionResponse;
+import com.opsmatters.newrelic.api.model.graphql.ThirdPartyMetricsResponse;
 import com.opsmatters.newrelic.api.model.insights.Dashboard;
 import com.opsmatters.newrelic.api.model.labels.Label;
 import com.opsmatters.newrelic.api.model.metrics.Metric;
@@ -214,6 +216,7 @@ public final class GsonMessageBodyHandler implements MessageBodyWriter<Object>, 
     private static final Type NRQL_ERROR_TYPE = new TypeToken<Collection<NrqlErrorResponse>>(){}.getType();
     private static final Type NRQL_QUERY_TYPE = new TypeToken<Collection<NrqlQueryResponse>>(){}.getType();
     private static final Type SLO_DEFINITION_TYPE = new TypeToken<Collection<SloDefinitionResponse>>(){}.getType();
+    private static final Type THIRD_PARTY_METRICS_RESPONSE = new TypeToken<Collection<ThirdPartyMetricsResponse>>(){}.getType();
 
     private Gson gson;
 
@@ -314,6 +317,10 @@ public final class GsonMessageBodyHandler implements MessageBodyWriter<Object>, 
             builder.registerTypeAdapter(NRQL_QUERY_TYPE, new NrqlQueryResponseDeserializer());
             builder.registerTypeAdapter(SloDefinitionResponse.class, new SloDefinitionResponseDeserializer());
             builder.registerTypeAdapter(SLO_DEFINITION_TYPE, new SloDefinitionResponseDeserializer());
+            builder.registerTypeAdapter(ThirdPartyMetricsResponse.class, new ThirdPartyMetricsResponseDeserializer());
+            builder.registerTypeAdapter(THIRD_PARTY_METRICS_RESPONSE, new ThirdPartyMetricsResponseDeserializer());
+
+
 
             gson = builder.create();
         }

--- a/src/main/java/com/opsmatters/newrelic/api/httpclient/deserializers/graphql/ThirdPartyMetricsResponseDeserializer.java
+++ b/src/main/java/com/opsmatters/newrelic/api/httpclient/deserializers/graphql/ThirdPartyMetricsResponseDeserializer.java
@@ -1,0 +1,19 @@
+package com.opsmatters.newrelic.api.httpclient.deserializers.graphql;
+
+import com.google.gson.*;
+import com.opsmatters.newrelic.api.model.graphql.ThirdPartyMetricsResponse;
+
+import java.lang.reflect.Type;
+
+public class ThirdPartyMetricsResponseDeserializer implements JsonDeserializer<ThirdPartyMetricsResponse> {
+    private static Gson gson = new Gson();
+
+    @Override
+    public ThirdPartyMetricsResponse deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        JsonObject obj = jsonElement.getAsJsonObject();
+        JsonElement data = obj.get("data");
+        if (data != null && data.isJsonObject())
+            return gson.fromJson(data, ThirdPartyMetricsResponse.class);
+        return null;
+    }
+}

--- a/src/main/java/com/opsmatters/newrelic/api/model/graphql/ThirdPartyMetricsResponse.java
+++ b/src/main/java/com/opsmatters/newrelic/api/model/graphql/ThirdPartyMetricsResponse.java
@@ -1,0 +1,120 @@
+package com.opsmatters.newrelic.api.model.graphql;
+
+import java.util.List;
+
+public class ThirdPartyMetricsResponse {
+    private Actor actor;
+
+    public ThirdPartyMetricsResponse() {
+    }
+
+    public Actor getActor() {
+        return actor;
+    }
+
+    public void setActor(Actor actor) {
+        this.actor = actor;
+    }
+
+    public class Actor {
+        private List<Entity> entities;
+
+        public List<Entity> getEntities() {
+            return entities;
+        }
+
+        public void setEntities(List<Entity> entities) {
+            this.entities = entities;
+        }
+    }
+
+    public class Entity {
+        private String guid;
+        private String name;
+        private GoldenMetrics goldenMetrics;
+
+        public String getGuid() {
+            return guid;
+        }
+
+        public void setGuid(String guid) {
+            this.guid = guid;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public GoldenMetrics getGoldenMetrics() {
+            return goldenMetrics;
+        }
+
+        public void setGoldenMetrics(GoldenMetrics goldenMetrics) {
+            this.goldenMetrics = goldenMetrics;
+        }
+    }
+
+    public class GoldenMetrics {
+        private List<Metrics> metrics;
+
+        public List<Metrics> getMetrics() {
+            return metrics;
+        }
+
+        public void setMetrics(List<Metrics> metrics) {
+            this.metrics = metrics;
+        }
+    }
+
+    public class Metrics {
+        private String metricName;
+        private String name;
+        private String query;
+        private String title;
+        private String unit;
+
+        public String getMetricName() {
+            return metricName;
+        }
+
+        public void setMetricName(String metricName) {
+            this.metricName = metricName;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getQuery() {
+            return query;
+        }
+
+        public void setQuery(String query) {
+            this.query = query;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getUnit() {
+            return unit;
+        }
+
+        public void setUnit(String unit) {
+            this.unit = unit;
+        }
+    }
+}

--- a/src/main/java/com/opsmatters/newrelic/api/services/BaseFluent.java
+++ b/src/main/java/com/opsmatters/newrelic/api/services/BaseFluent.java
@@ -45,6 +45,7 @@ import com.opsmatters.newrelic.api.model.graphql.EntityAccountLookupResponse;
 import com.opsmatters.newrelic.api.model.graphql.EntityLookupResponse;
 import com.opsmatters.newrelic.api.model.graphql.NrqlQueryResponse;
 import com.opsmatters.newrelic.api.model.graphql.SloDefinitionResponse;
+import com.opsmatters.newrelic.api.model.graphql.ThirdPartyMetricsResponse;
 import com.opsmatters.newrelic.api.model.transactions.KeyTransaction;
 import com.opsmatters.newrelic.api.model.plugins.Plugin;
 import com.opsmatters.newrelic.api.model.plugins.PluginComponent;
@@ -175,6 +176,7 @@ public class BaseFluent
     protected static final GenericType<EntityAccountLookupResponse> ENTITY_ACCOUNT_LOOKUP = new GenericType<EntityAccountLookupResponse>(){};
     protected static final GenericType<AccountLookupResponse> ACCOUNT_LOOKUP = new GenericType<AccountLookupResponse>(){};
     protected static final GenericType<SloDefinitionResponse> SLO_DEFINITION = new GenericType<SloDefinitionResponse>(){};
+    protected static final GenericType<ThirdPartyMetricsResponse> THIRD_PARTY_METRICS_RESPONSE = new GenericType<ThirdPartyMetricsResponse>(){};
 
     protected static final GenericType<NrqlQueryResponse> NRQL_QUERY = new GenericType<NrqlQueryResponse>(){};
 

--- a/src/main/java/com/opsmatters/newrelic/api/services/GraphQLService.java
+++ b/src/main/java/com/opsmatters/newrelic/api/services/GraphQLService.java
@@ -91,6 +91,17 @@ public class GraphQLService extends BaseFluent {
         return HTTP.POST("/graphql", request, SLO_DEFINITION);
     }
 
+    /**
+     * Returns the ThirdPartyMetricsResponse
+     * @param guids The entity guid to search for
+     * @return The metrics data
+     */
+    public Optional<ThirdPartyMetricsResponse> searchThirdPartyMetrics(List<String> guids)
+    {
+        GraphQLRequest request = GraphQLRequest.from(constructThirdPartyMetrics(guids));
+        return HTTP.POST("/graphql", request, THIRD_PARTY_METRICS_RESPONSE);
+    }
+
     private String constructNrqlQuery(int accountId, String query) {
         return "{" +
                 "  actor {" +
@@ -175,6 +186,28 @@ public class GraphQLService extends BaseFluent {
                "      }" +
                "    }" +
                "  }" +
-              "}";
+               "}";
+    }
+
+    private String constructThirdPartyMetrics(List<String> guids) {
+        return "{" +
+               "  actor {" +
+               "    entities(guids: [" + guids.stream().collect(Collectors.joining(",", "'", "'")) + "]) {" +
+               "      ... on ThirdPartyServiceEntity {" +
+               "        guid" +
+               "        name" +
+               "        goldenMetrics {" +
+               "          metrics {" +
+               "            query" +
+               "            name" +
+               "            metricName" +
+               "            title" +
+               "            unit" +
+               "          }" +
+               "        }" +
+               "      }" +
+               "    }" +
+               "  }" +
+               "}";
     }
 }

--- a/src/main/java/com/opsmatters/newrelic/api/services/GraphQLService.java
+++ b/src/main/java/com/opsmatters/newrelic/api/services/GraphQLService.java
@@ -192,7 +192,7 @@ public class GraphQLService extends BaseFluent {
     private String constructThirdPartyMetrics(List<String> guids) {
         return "{" +
                "  actor {" +
-               "    entities(guids: [" + guids.stream().collect(Collectors.joining(",", "'", "'")) + "]) {" +
+               "    entities(guids: [" + guids.stream().collect(Collectors.joining(",", "\"", "\"")) + "]) {" +
                "      ... on ThirdPartyServiceEntity {" +
                "        guid" +
                "        name" +


### PR DESCRIPTION
## Background
Support for open telemetry for new relic summary: https://cortex1.atlassian.net/browse/CET-10054

## This PR
Added support for new graphql query for retrieving thrid party applications summary - wchich contains data send by OTEL