### PR TITLE
CET-12368 Handle timeout for nrql queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.brainera</groupId>
   <artifactId>newrelic-api</artifactId>
-  <version>1.0.26</version>
+  <version>1.0.27</version>
   <packaging>jar</packaging>
   <name>New Relic API</name>
   <description>

--- a/src/main/java/com/opsmatters/newrelic/api/services/GraphQLService.java
+++ b/src/main/java/com/opsmatters/newrelic/api/services/GraphQLService.java
@@ -81,6 +81,18 @@ public class GraphQLService extends BaseFluent {
     }
 
     /**
+     * Returns the GraphQL response
+     * @param query The NRQL query to execute
+     * @param timeout The NRQL query execution timeout
+     * @return The query data
+     */
+    public Optional<NrqlQueryResponse> runNrql(int accountId, String query, int timeout)
+    {
+        GraphQLRequest request = GraphQLRequest.from(constructNrqlQueryWithTimeout(accountId, query, timeout));
+        return HTTP.POST("/graphql", request, NRQL_QUERY);
+    }
+
+    /**
      * Returns the SloDefinitionResponse
      * @param newRelicEntityGuid The entity guid to search for
      * @return The query data
@@ -107,6 +119,18 @@ public class GraphQLService extends BaseFluent {
                 "  actor {" +
                 "    account(id: " + accountId + ") {" +
                 "      nrql(query: \"" + query + "\") {" +
+                "        results" +
+                "      }" +
+                "    }" +
+                "  }" +
+                "}";
+    }
+
+    private String constructNrqlQueryWithTimeout(int accountId, String query, int timeout) {
+        return "{" +
+                "  actor {" +
+                "    account(id: " + accountId + ") {" +
+                "      nrql(query: \"" + query + "\", timeout: " + timeout + ") {" +
                 "        results" +
                 "      }" +
                 "    }" +


### PR DESCRIPTION
## Description

Added support for specifying timeout for nrql queries because default value (5s) is not enough for skyscanner tenant: https://cortex1.atlassian.net/browse/CET-12368