### PR TITLE
CET-15692 Deserialize GraphQL response as error response if errors present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.brainera</groupId>
   <artifactId>newrelic-api</artifactId>
-  <version>1.0.29</version>
+  <version>1.0.30</version>
   <packaging>jar</packaging>
   <name>New Relic API</name>
   <description>

--- a/src/main/java/com/opsmatters/newrelic/api/httpclient/deserializers/graphql/NrqlQueryResponseDeserializer.java
+++ b/src/main/java/com/opsmatters/newrelic/api/httpclient/deserializers/graphql/NrqlQueryResponseDeserializer.java
@@ -30,10 +30,10 @@ public class NrqlQueryResponseDeserializer implements JsonDeserializer<NrqlQuery
         JsonObject obj = element.getAsJsonObject();
         JsonElement data = obj.get("data");
         JsonElement errors = obj.get("errors");
-        if(data != null && data.isJsonObject())
-            return gson.fromJson(data, NrqlSuccessResponse.class);
-        else if(errors != null && obj.isJsonObject()) {
+        if(errors != null && obj.isJsonObject()) {
             return gson.fromJson(obj, NrqlErrorResponse.class);
+        } else if(data != null && data.isJsonObject()) {
+            return gson.fromJson(data, NrqlSuccessResponse.class);
         }
         return null;
     }


### PR DESCRIPTION
## Change description

https://cortex1.atlassian.net/browse/CET-15692
Error responses from Newrelic's NerdGraph API are currently being deserialized as success responses because they contain a non-null `body` in addition to `errors`. This change fixes the deserializer to prefer the error type if `errors` is present.

This assumes we will not receive both a valid response and an `errors` field. Existing traffic shows that this should be the case. If we wanted to handle a response containing both, we would have to do away with the class hierarchy, include both fields on the response type, and do error and response checking in the service layer when we use the client.